### PR TITLE
Add query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .classpath
 /build/
 /target/
+.idea
+JRest.iml

--- a/src/main/java/com/animo/jRest/annotation/Query.java
+++ b/src/main/java/com/animo/jRest/annotation/Query.java
@@ -1,0 +1,20 @@
+package com.animo.jRest.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Named replacement in a URL query parameters segment. Values are converted to strings using the Parameters passed to the request Method
+ * <p>For Example :
+ * <pre><code>
+ * &#64;REQUEST(endpoint = "/book",type = HTTP_METHOD.GET)
+ * APICall<Void,ApiResponse> getSingleQParamCall(@Query(value = "author") String author);
+ * </code></pre>
+ * @author harshit
+ *
+ */
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Query {
+    String value();
+}

--- a/src/main/java/com/animo/jRest/annotation/QueryMap.java
+++ b/src/main/java/com/animo/jRest/annotation/QueryMap.java
@@ -1,0 +1,21 @@
+package com.animo.jRest.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Adds query parameters dynamically via parameters , literally supplied via a Map<String,String>
+ *
+ * <pre><code>
+ *
+ * &#64;REQUEST(endpoint = "/get",type=HTTP_METHOD.GET)
+ APICall<Void,Map<String,Object>> getQParamMapCall(@QueryMap Map<String, String> queryMap);
+ * </code></pre>
+ *
+ * @author harshit
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface QueryMap {
+}

--- a/src/test/java/com/animo/jRest/test/QueryParamTest.java
+++ b/src/test/java/com/animo/jRest/test/QueryParamTest.java
@@ -1,0 +1,62 @@
+package com.animo.jRest.test;
+
+import com.animo.jRest.util.APICall;
+import com.animo.jRest.util.APIHelper;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertTrue;
+
+public class QueryParamTest {
+
+    @Ignore
+    @Test
+    public void testSingleQueryParam() throws Exception {
+
+        final APIHelper testAPIHelper = APIHelper.APIBuilder
+                .builder("https://postman-echo.com")
+                .build();
+        final TestPostmanEchoAPIInterface testInterface = testAPIHelper.createApi(TestPostmanEchoAPIInterface.class);
+        String foo1 = "bar"+(new Random().nextInt(60000));
+        final APICall<Void, Map<String, Object>> testCall = testInterface.getSingleQParamCall(foo1);
+        final APICall<Void, Map<String, Object>> response = testCall.callMeNow();
+        assertTrue(response.getResponseCode()==200);
+
+    }
+
+    @Ignore
+    @Test
+    public void testMultipleQueryParam() throws Exception {
+
+        final APIHelper testAPIHelper = APIHelper.APIBuilder
+                .builder("https://postman-echo.com")
+                .build();
+        final TestPostmanEchoAPIInterface testInterface = testAPIHelper.createApi(TestPostmanEchoAPIInterface.class);
+        String foo1 = "bar"+(new Random().nextInt(60000));
+        String foo2 = "bar"+(new Random().nextInt(60000));
+        final APICall<Void, Map<String, Object>> testCall = testInterface.getMultipleQParamCall(foo1, foo2);
+        final APICall<Void, Map<String, Object>> response = testCall.callMeNow();
+        assertTrue(response.getResponseCode()==200);
+
+    }
+    @Ignore
+    @Test
+    public void testQueryMap() throws Exception {
+
+        final APIHelper testAPIHelper = APIHelper.APIBuilder
+                .builder("https://postman-echo.com")
+                .build();
+        final TestPostmanEchoAPIInterface testInterface = testAPIHelper.createApi(TestPostmanEchoAPIInterface.class);
+        Map<String,String> paramMap = new HashMap<>();
+        paramMap.put("foo1", "bar"+(new Random().nextInt(10)));
+        paramMap.put("foo2", "bar"+(new Random().nextInt(10)));
+        final APICall<Void, Map<String, Object>> testCall = testInterface.getQParamMapCall(paramMap);
+        final APICall<Void, Map<String, Object>> response = testCall.callMeNow();
+        assertTrue(response.getResponseCode()==200);
+
+    }
+}

--- a/src/test/java/com/animo/jRest/test/TestPostmanEchoAPIInterface.java
+++ b/src/test/java/com/animo/jRest/test/TestPostmanEchoAPIInterface.java
@@ -2,14 +2,23 @@ package com.animo.jRest.test;
 
 import java.util.Map;
 
-import com.animo.jRest.annotation.HEADER;
-import com.animo.jRest.annotation.HEADERS;
-import com.animo.jRest.annotation.REQUEST;
+import com.animo.jRest.annotation.*;
 import com.animo.jRest.util.APICall;
 import com.animo.jRest.util.HTTP_METHOD;
 
 public interface TestPostmanEchoAPIInterface {
-	
+
+	//	For Query Parameters Test
+	@REQUEST(endpoint = "/get", type = HTTP_METHOD.GET)
+	APICall<Void, Map<String, Object>> getSingleQParamCall(@Query(value = "foo1")String foo1);
+
+	@REQUEST(endpoint = "/get", type = HTTP_METHOD.GET)
+	APICall<Void, Map<String, Object>> getMultipleQParamCall(@Query(value = "foo1")String foo1, @Query("foo2")String foo2);
+
+	@REQUEST(endpoint = "/get", type = HTTP_METHOD.GET)
+	APICall<Void, Map<String, Object>> getQParamMapCall(@QueryMap Map<String, String> queryMap);
+
+	//	For Headers Test
 	@REQUEST(endpoint = "/get", type = HTTP_METHOD.GET)
 	@HEADERS("X-Foo:Bar")
 	APICall<Void, Map<String, Object>> getCall();


### PR DESCRIPTION
Reference Issue: https://github.com/animo93/JRest/issues/5

Changes:
a) added Annotations `@Query` and `@QueryMap` for query parameters support as method parameters in the API call interface.
b) modified APIHelper to process and add query parameters as query string in the final URL.
c) added QueryParamTest to test auery paramters.

Extra:
modified APIAsyncTask to support 'http' protocol calls.